### PR TITLE
Feature: flag to save bigtiff

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "dev*"]
+
+jobs:
+  build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9"]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest pytest-xdist pytest-cov
+        python -m pip install -e .
+    - name: Test with pytest
+      run: |
+        pytest

--- a/jnormcorre/motion_correction.py
+++ b/jnormcorre/motion_correction.py
@@ -64,7 +64,7 @@ from skimage.transform import resize as resize_sk
 from skimage.transform import warp as warp_sk
 
 from jnormcorre.onephotonmethods import get_kernel, high_pass_filter_cv, high_pass_batch
-import jnormcorre.utils.movies
+import jnormcorre.utils.movies as movies
 from jnormcorre.utils.movies import load, load_iter
 
 import pathlib ##MOVE THIS ONE...
@@ -205,7 +205,7 @@ def get_file_size(file_name, var_name_hdf5='mov'):
                 # Consider pulling a lot of the "data source" code out into one place
                 with h5py.File(file_name, "r") as f:
                     kk = list(f.keys())
-                    if len(kk) == 1:
+                    if len(kk) == 1 and var_name_hdf5 not in f:
                         siz = f[kk[0]].shape
                     elif var_name_hdf5 in f:
                         if extension == '.nwb':
@@ -381,11 +381,19 @@ class MotionCorrect(object):
         """
         if 'ndarray' in str(type(fname)):
             logging.info('Creating file for motion correction "tmp_mov_mot_corr.hdf5"')
-            utils.movies.movie(fname).save('tmp_mov_mot_corr.hdf5')
+            movies.movie(fname).save('tmp_mov_mot_corr.hdf5', var_name_hdf5=var_name_hdf5)
             fname = ['tmp_mov_mot_corr.hdf5']
 
         if not isinstance(fname, list):
             fname = [fname]
+
+        if not isinstance(niter_els, int) or niter_els < 1:
+            raise ValueError(f"please provide n_iter as an int of 1 or higher.")
+
+        if not isinstance(var_name_hdf5, str):
+            raise ValueError(f"pleaes provide 'var_name_hdf5' as string")
+
+        # if max_shifts
 
         self.fname = fname
         self.max_shifts = max_shifts
@@ -442,7 +450,7 @@ class MotionCorrect(object):
                 self.min_mov = mi
             else: 
                 self.min_mov = np.array([high_pass_filter_cv(m_, self.filter_kernel)
-                    for m_ in jnormcorre.utils.movies.load(self.fname[0], var_name_hdf5=self.var_name_hdf5,
+                    for m_ in movies.load(self.fname[0], var_name_hdf5=self.var_name_hdf5,
                                       subindices=slice(400))]).min()
 
 
@@ -1842,7 +1850,7 @@ def tile_and_correct_rigid_1p(img, img_filtered, template, max_shifts, add_to_mo
 
     return new_img - add_to_movie, jnp.array([-rigid_shts[0], -rigid_shts[1]])
 
-tile_and_correct_rigid_1p_vmap = jit(vmap(tile_and_correct_rigid_1p, in_axes=(0, 0, None, None, None, None)))
+tile_and_correct_rigid_1p_vmap = jit(vmap(tile_and_correct_rigid_1p, in_axes=(0, 0, None, (None, None), None)))
         
         
 # @partial(jit, static_argnums=(3,))
@@ -2325,7 +2333,7 @@ def motion_correct_batch_rigid(fname, max_shifts, splits=56, num_splits_to_proce
 
     if template is None:
         if filter_kernel is not None:
-            m = jnormcorre.utils.movies.movie(
+            m = movies.movie(
                 np.array([high_pass_filter_cv(filter_kernel, m_) for m_ in m]))
             
         if not m.flags['WRITEABLE']:
@@ -2625,7 +2633,7 @@ def tile_and_correct_dataloader(param_list, split_constant=200, bigtiff=False):
                     outs= tile_and_correct_rigid_vmap(imgs, template, max_shifts, add_to_movie)
                 else:
                     imgs_filtered = high_pass_batch(filter_kernel, imgs)
-                    outs = tile_and_correct_rigid_1p_vmap(imgs, imgs_filtered, template, max_shifts, upsample_factor_fft, add_to_movie)
+                    outs = tile_and_correct_rigid_1p_vmap(imgs, imgs_filtered, template, max_shifts, add_to_movie)
                 mc[start_pt:end_pt, :, :] = outs[0]
                 temp_Nones_1 = [None for temp_i in range(outs[1].shape[0])]
                 shift_info.extend(list(zip(np.array(outs[1]), temp_Nones_1, temp_Nones_1)))

--- a/jnormcorre/simulation.py
+++ b/jnormcorre/simulation.py
@@ -1,0 +1,217 @@
+import numpy as np
+from scipy.ndimage import affine_transform
+from tifffile import imsave
+from pathlib import Path
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+
+
+class SimData:
+    def __init__(self, frames, X, Y, n_blobs=10, noise_amplitude=1.0, blob_amplitude=1.0,
+                 max_drift=0.5, max_jitter=2.0, background_noise=1.0, shot_noise=0.1):
+        """
+        Initialize the SimData object with the given parameters.
+
+        Parameters:
+        - frames: Number of frames in the simulation.
+        - X, Y: Dimensions of the images.
+        - n_blobs: Number of gaussian blobs (peaks or valleys) to add to the base image.
+        - noise_amplitude: Amplitude of the noise in the base image.
+        - blob_amplitude: Amplitude of the gaussian blobs.
+        - max_drift: Maximum drift value or tuple for quadratic drift.
+        - max_jitter: Maximum random jitter in the image per frame.
+        - background_noise: Constant background noise level.
+        - shot_noise: Frame-by-frame noise level.
+        """
+
+        # Basic parameters
+        self.frames = frames
+        self.X = X
+        self.Y = Y
+        self.n_blobs = n_blobs
+        self.noise_amplitude = noise_amplitude
+        self.blob_amplitude = blob_amplitude
+        self.data = None
+        self.shifts = None
+        self.max_jitter = max_jitter
+        self.background_noise = background_noise
+        self.shot_noise = shot_noise
+
+        # Determine if the drift is linear or quadratic, and randomize parameters accordingly
+        if isinstance(max_drift, tuple):
+            self.drift_type = 'quadratic'
+            self.a_x = np.random.uniform(-max_drift[0], max_drift[0])
+            self.a_y = np.random.uniform(-max_drift[0], max_drift[0])
+            self.b_x = np.random.uniform(-max_drift[1], max_drift[1])
+            self.b_y = np.random.uniform(-max_drift[1], max_drift[1])
+        else:
+            self.drift_type = 'linear'
+            self.m_x = np.random.uniform(-max_drift, max_drift)
+            self.m_y = np.random.uniform(-max_drift, max_drift)
+
+    def generate_gaussian_blob(self, x, y, x0, y0, sigma, amplitude):
+        """
+        Generate a 2D Gaussian blob at a given location with specified parameters.
+
+        Parameters:
+        - x, y: Meshgrid for the image dimensions.
+        - x0, y0: Center of the gaussian blob.
+        - sigma: Standard deviation of the gaussian blob.
+        - amplitude: Amplitude of the gaussian blob (can be negative for valleys).
+
+        Returns:
+        - 2D numpy array representing the gaussian blob.
+        """
+        return amplitude * np.exp(-((x-x0)**2 + (y-y0)**2) / (2 * sigma**2))
+
+    def generate_base_image(self, padding=0):
+        """
+        Generate a base image consisting of a noise floor and random gaussian blobs.
+
+        Parameters:
+        - padding: Additional space around the image to account for movement.
+
+        Returns:
+        - Padded base image with noise and gaussian blobs.
+        """
+        X_padded = self.X + 2 * padding
+        Y_padded = self.Y + 2 * padding
+
+        # Create a noise floor using random values
+        noise_floor = self.background_noise * np.random.randn(X_padded, Y_padded)
+
+        x = np.arange(X_padded)
+        y = np.arange(Y_padded)
+        x, y = np.meshgrid(x, y)
+
+        # Add random gaussian blobs (peaks or valleys) to the noise floor
+        for _ in range(self.n_blobs):
+            x0 = np.random.randint(X_padded)
+            y0 = np.random.randint(Y_padded)
+            sigma = np.random.uniform(5, 15)
+            if np.random.rand() < 0.5:
+                amplitude = np.random.uniform(1, self.blob_amplitude)
+            else:
+                amplitude = np.random.uniform(-1, -self.blob_amplitude)
+            noise_floor += self.generate_gaussian_blob(x, y, x0, y0, sigma, amplitude)
+        return noise_floor
+
+    def calculate_padding(self):
+        """
+        Calculate the necessary padding around the image to ensure that the entire
+        field of view stays within the base image, even with maximum drift and jitter.
+
+        Returns:
+        - Amount of padding needed.
+        """
+        if self.drift_type == 'linear':
+            max_drift_x = self.m_x * self.frames
+            max_drift_y = self.m_y * self.frames
+        else:
+            max_drift_x = self.a_x * self.frames**2 + self.b_x * self.frames
+            max_drift_y = self.a_y * self.frames**2 + self.b_y * self.frames
+        total_max_shift_x = max_drift_x + self.frames * self.max_jitter
+        total_max_shift_y = max_drift_y + self.frames * self.max_jitter
+        return int(max(total_max_shift_x, total_max_shift_y))
+
+    def simulate(self):
+        """
+        Simulate a sequence of images with drift and jitter.
+
+        Returns:
+        - Simulated data and list of shifts for each frame.
+        """
+        padding = self.calculate_padding()
+        large_base_image = self.generate_base_image(padding)
+        self.data = np.zeros((self.frames, self.X, self.Y))
+        shifts = []
+        for t in tqdm(range(self.frames)):
+            # Add random jitter for the current frame
+            jitter_x = np.random.uniform(-self.max_jitter, self.max_jitter)
+            jitter_y = np.random.uniform(-self.max_jitter, self.max_jitter)
+
+            # Calculate the drift for the current frame (linear or quadratic)
+            if self.drift_type == 'linear':
+                drift_x = self.m_x * t
+                drift_y = self.m_y * t
+            else:
+                drift_x = self.a_x * t**2 + self.b_x * t
+                drift_y = self.a_y * t**2 + self.b_y * t
+
+            # Combine the drift and jitter to get the total shift for the current frame
+            shift_x = jitter_x + drift_x
+            shift_y = jitter_y + drift_y
+            shifts.append((shift_x, shift_y))
+
+            # Apply the shift using an affine transformation
+            transformation_matrix = np.array([[1, 0, -shift_x], [0, 1, -shift_y], [0, 0, 1]])
+            shifted_image = affine_transform(large_base_image, transformation_matrix[:2, :2],
+                                             offset=transformation_matrix[:2, 2], mode='nearest', order=1)
+
+            # Add frame-by-frame shot noise to the image
+            shifted_image += self.shot_noise * np.random.randn(self.X + 2 * padding, self.Y + 2 * padding)
+
+            # Extract the relevant section of the shifted image for the current frame
+            start_x = padding
+            end_x = start_x + self.X
+            start_y = padding
+            end_y = start_y + self.Y
+            self.data[t] = shifted_image[start_x:end_x, start_y:end_y]
+        self.shifts = shifts
+        return self.data, shifts
+
+    def save(self, path):
+        """
+        Save the simulated data to a .tiff file.
+
+        Parameters:
+        - path: Destination path for the .tiff file.
+        """
+        path = Path(path)
+        imsave(path, self.data.astype(np.float32))
+
+    def plot_overview(self, savefig=None):
+        """
+        Plot an overview of the simulated data, showing the first, middle, and last frames,
+        as well as the shifts in the x and y directions over time.
+        """
+        shifts_x = [s[0] for s in self.shifts]
+        shifts_y = [s[1] for s in self.shifts]
+
+        fig, axs = plt.subplots(1, 4, figsize=(20, 5))
+
+        axs[0].imshow(self.data[0], cmap='gray')
+        axs[0].set_title('First Frame')
+
+        axs[1].imshow(self.data[self.frames//2], cmap='gray')
+        axs[1].set_title('Middle Frame')
+
+        axs[2].imshow(self.data[-1], cmap='gray')
+        axs[2].set_title('Last Frame')
+
+        axs[3].plot(shifts_x, label='Shift X')
+        axs[3].plot(shifts_y, label='Shift Y')
+        axs[3].set_title('Shifts over Time')
+        axs[3].set_xlabel('Frame')
+        axs[3].legend()
+
+        for ax in axs[:3]:
+            ax.axis('off')
+
+        plt.tight_layout()
+
+        if savefig is None:
+            plt.show()
+        else:
+            fig.savefig(savefig)
+
+if __name__ == "__main__":
+
+    save_path = "../test/test.png"
+
+    sim_data_obj_new = SimData(frames=250, X=50, Y=50, n_blobs=10, noise_amplitude=0.2,
+                           blob_amplitude=5, max_drift=(0.0001, 0.01), max_jitter=1,
+                           background_noise=1, shot_noise=0.2)
+
+    data_new, shifts_new = sim_data_obj_new.simulate()
+    sim_data_obj_new.plot_overview(savefig=save_path)

--- a/jnormcorre/utils/movies.py
+++ b/jnormcorre/utils/movies.py
@@ -311,6 +311,12 @@ class movie(ts.timeseries):
         ms_w = max_shift_w
         ms_h = max_shift_h
 
+        if ms_w >= w_i / 2:
+            raise ValueError(f"max_shift[0] must be smaller than half of image width")
+
+        if ms_h >= h_i / 2:
+            raise ValueError(f"max_shift[1] must be smaller than half of image height")
+
         if template is None:
             template = np.median(self, axis=0)
         else:
@@ -911,9 +917,6 @@ def load(file_name: Union[str, List[str]],
 
         elif extension in ('.hdf5', '.h5', '.nwb'):
            with h5py.File(file_name, "r") as f:
-                fkeys = list(f.keys())
-                if len(fkeys) == 1: # If the hdf5 file we're parsing has only one dataset inside it, ignore the arg and pick that dataset
-                    var_name_hdf5 = fkeys[0]
 
                 if extension == '.nwb': # Apparently nwb files are specially-formatted hdf5 files
                     try:

--- a/test/test_motion_correction.py
+++ b/test/test_motion_correction.py
@@ -1,0 +1,219 @@
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+import tifffile
+import h5py
+import logging
+
+from jnormcorre.simulation import SimData
+from jnormcorre.motion_correction import MotionCorrect
+
+class Test_Simulation:
+
+    def test_init(self, frames=100, X=100, Y=100):
+        sim = SimData(frames=frames, X=X, Y=Y, n_blobs=10, noise_amplitude=0.2,
+                           blob_amplitude=5, max_drift=(0.0001, 0.01), max_jitter=1,
+                           background_noise=1, shot_noise=0.2)
+
+    def test_run(self, frames=100, X=100, Y=100):
+
+        sim = SimData(frames=frames, X=X, Y=Y, n_blobs=10, noise_amplitude=0.2,
+                           blob_amplitude=5, max_drift=(0.0001, 0.01), max_jitter=1,
+                           background_noise=1, shot_noise=0.2)
+
+        _, _ = sim.simulate()
+
+class Test_mc:
+
+    def save_sample(self, input_, data, h5_loc=None):
+
+        if isinstance(input_, np.ndarray):
+            return input_
+
+        input_ = Path(input_)
+
+        # save temp file
+        if input_.suffix in ('.tiff', '.tif'):
+            tifffile.imwrite(input_, data=data)
+
+        elif input_.suffix in ('.h5', '.hdf5'):
+
+            with h5py.File(input_.as_posix(), "w") as h:
+                # h.create_group("data")
+                ds = h.create_dataset(h5_loc, data=data, shape=data.shape, dtype=data.dtype)
+                ds[:] = data[:]
+
+        else:
+            raise ValueError(f"unknown file extension: {input_.suffix}")
+
+        return input_
+
+    def setup_method(self):
+
+        frames, X, Y = (25, 80, 80)
+        sim = SimData(frames=frames, X=X, Y=Y, n_blobs=10, noise_amplitude=0.2,
+                           blob_amplitude=5, max_drift=(0.0001, 0.01), max_jitter=1,
+                           background_noise=1, shot_noise=0.2)
+
+        data, shifts = sim.simulate()
+        self.data = data
+        self.shifts = shifts
+
+    @pytest.mark.parametrize("file_type", [("test.tiff", ""), ("test.h5", "data"),
+                                           ("test.h5", "data/ch0"), ("test.h5", "data/ch0/dff")])
+    def test_file(self, file_type):
+
+        name, h5_loc = file_type
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+
+            # create sim data
+            data, shifts = self.data, self.shifts
+            input_ = self.save_sample(tmp_dir.joinpath(name), data, h5_loc=h5_loc)
+
+            mc = MotionCorrect(input_, var_name_hdf5=h5_loc,
+                               max_shifts=(6, 6), niter_rig=4, nonneg_movie=True, max_deviation_rigid=3,
+                               upsample_factor_grid=4, strides=(50, 50), splits_rig=5, splits_els=5, gSig_filt=None,
+                               num_splits_to_process_els=5, num_splits_to_process_rig=5, pw_rigid=True,
+                               overlaps=(10, 10), min_mov=-5, niter_els=1)
+
+            # Perform motion correction
+            mc.motion_correct(save_movie=True)
+            self.shifts = mc.shifts_rig
+
+    @pytest.mark.parametrize("max_shifts", [(6, 6), (39, 39)])
+    @pytest.mark.parametrize("num_splits_to_process_rig", [5])
+    @pytest.mark.parametrize("num_splits_to_process_els", [5])
+    @pytest.mark.parametrize("splits_els", [5])
+    @pytest.mark.parametrize("splits_rig", [5])
+    @pytest.mark.parametrize("gSig_filt", [None, (10, 10)])
+    @pytest.mark.parametrize("overlaps", [(10, 10), (24, 24)])
+    @pytest.mark.parametrize("pw_rigid", [True, False])
+    @pytest.mark.parametrize("min_mov", [None, -5, 5])
+    @pytest.mark.parametrize("niter_els", [1, 3])
+    def test_parameters(self, max_shifts, num_splits_to_process_rig, num_splits_to_process_els,
+                  gSig_filt, overlaps, pw_rigid, splits_els, splits_rig, min_mov, niter_els,
+                   niter_rig=4, nonneg_movie=True, max_deviation_rigid=3, upsample_factor_grid=4, strides=(50, 50)):
+
+        input_, shifts = self.data, self.shifts
+
+        # Create MotionCorrect instance
+        mc = MotionCorrect(input_,
+                max_shifts=max_shifts, niter_rig=niter_rig, splits_rig=splits_rig,
+                num_splits_to_process_rig=num_splits_to_process_rig, strides=strides, overlaps=overlaps,
+                pw_rigid=pw_rigid, splits_els=splits_els, num_splits_to_process_els=num_splits_to_process_els,
+                upsample_factor_grid=upsample_factor_grid, max_deviation_rigid=max_deviation_rigid,
+                nonneg_movie=nonneg_movie, gSig_filt=gSig_filt,
+                           min_mov=min_mov, niter_els=niter_els)
+
+        # Perform motion correction
+        mc.motion_correct(save_movie=True)
+        calc_shifts = mc.shifts_rig
+
+        # test correct shift reconstruction
+        np.allclose(shifts, calc_shifts), f"calculated shifts are to different from True value"
+
+    @pytest.mark.parametrize("num_splits_to_process_els", [5, 10])
+    @pytest.mark.parametrize("splits_els", [5, 10])
+    @pytest.mark.parametrize("niter_els", [1, 3])
+    def test_els_split(self, num_splits_to_process_els, splits_els, niter_els, pw_rigid=True):
+
+        input_, shifts = self.data, self.shifts
+
+        # Create MotionCorrect instance
+        mc = MotionCorrect(input_,
+                max_shifts=(6, 6), niter_rig=4, splits_rig=5,
+                num_splits_to_process_rig=5, strides=(50, 50), overlaps=(10, 10),
+                pw_rigid=pw_rigid, splits_els=splits_els, num_splits_to_process_els=num_splits_to_process_els,
+                upsample_factor_grid=4, max_deviation_rigid=3,
+                nonneg_movie=True, gSig_filt=None, min_mov=-1, niter_els=niter_els)
+
+        # Perform motion correction
+        mc.motion_correct(save_movie=True)
+
+    @pytest.mark.parametrize("num_splits_to_process_rig", [5, 10])
+    @pytest.mark.parametrize("splits_rig", [5, 10])
+    @pytest.mark.parametrize("niter_els", [1, 3])
+    def test_rig_split(self, num_splits_to_process_rig, splits_rig, niter_els, pw_rigid=True):
+
+        input_, shifts = self.data, self.shifts
+
+        # Create MotionCorrect instance
+        mc = MotionCorrect(input_,
+                max_shifts=(6, 6), niter_rig=4, splits_rig=splits_rig,
+                num_splits_to_process_rig=num_splits_to_process_rig, strides=(50, 50), overlaps=(10, 10),
+                pw_rigid=pw_rigid, splits_els=5, num_splits_to_process_els=5,
+                upsample_factor_grid=4, max_deviation_rigid=3,
+                nonneg_movie=True, gSig_filt=None, min_mov=-1, niter_els=niter_els)
+
+        # Perform motion correction
+        mc.motion_correct(save_movie=True)
+
+    @pytest.mark.parametrize("n_frames", [25, 100])
+    @pytest.mark.parametrize("pw_rigid", [True, False])
+    @pytest.mark.parametrize("max_drift", [(1e-1), (1e-4, 1e-2), (1e-3, 1e-2), (1e-3, 1e-1)])
+    def test_movement(self, n_frames, pw_rigid, max_drift, dim=80):
+
+        frames, X, Y = (n_frames, dim, dim)
+        max_shift = int(dim/2) - 1
+
+        # simulate movement artifacts
+        sim = SimData(frames=frames, X=X, Y=Y, n_blobs=10, noise_amplitude=0.2,
+                           blob_amplitude=5, max_drift=max_drift, max_jitter=1,
+                           background_noise=1, shot_noise=0.2)
+
+        data, shifts = sim.simulate()
+        assert np.max(shifts) < max_shift, f"simulated data deviates too much"
+
+        # Create MotionCorrect instance
+
+        mc = MotionCorrect(data,
+                max_shifts=(max_shift, max_shift), niter_rig=4, splits_rig=5,
+                num_splits_to_process_rig=5, strides=(50, 50), overlaps=(10, 10),
+                pw_rigid=pw_rigid, splits_els=5, num_splits_to_process_els=5,
+                upsample_factor_grid=4, max_deviation_rigid=3,
+                nonneg_movie=True, gSig_filt=None, min_mov=-1, niter_els=3)
+
+        # Perform motion correction
+        mc.motion_correct(save_movie=True)
+        calc_shifts = mc.shifts_rig
+
+        # test correct shift reconstruction
+        np.allclose(shifts, calc_shifts), f"calculated shifts are to different from True value"
+
+    @pytest.mark.xfail(reason="movement that exceeds capabilities")
+    @pytest.mark.parametrize("n_frames", [400])
+    @pytest.mark.parametrize("pw_rigid", [True, False])
+    @pytest.mark.parametrize("max_drift", [(1e-3, 1e-1), (1e-2, 1e-1)])
+    def test_movement_extreme(self, n_frames, pw_rigid, max_drift, dim=80):
+
+        frames, X, Y = (n_frames, dim, dim)
+        max_shift = int(dim/2) - 1
+
+        # simulate movement artifacts
+        sim = SimData(frames=frames, X=X, Y=Y, n_blobs=10, noise_amplitude=0.2,
+                           blob_amplitude=5, max_drift=max_drift, max_jitter=1,
+                           background_noise=1, shot_noise=0.2)
+
+        data, shifts = sim.simulate()
+        assert np.max(shifts) < max_shift, f"simulated data deviates too much"
+
+        # Create MotionCorrect instance
+
+        mc = MotionCorrect(data,
+                max_shifts=(max_shift, max_shift), niter_rig=4, splits_rig=5,
+                num_splits_to_process_rig=5, strides=(50, 50), overlaps=(10, 10),
+                pw_rigid=pw_rigid, splits_els=5, num_splits_to_process_els=5,
+                upsample_factor_grid=4, max_deviation_rigid=3,
+                nonneg_movie=True, gSig_filt=None, min_mov=-1, niter_els=3)
+
+        # Perform motion correction
+        mc.motion_correct(save_movie=True)
+        calc_shifts = mc.shifts_rig
+
+        # test correct shift reconstruction
+        np.allclose(shifts, calc_shifts), f"calculated shifts are to different from True value"
+


### PR DESCRIPTION
#### Description:

In the current implementation, writing large TIFF files may result in a "data too large for non-BigTIFF file" error due to the 4 GB size limitation of the standard TIFF format. This pull request introduces a flag to allow tifffile to save bigger tiff files 

#### Changes:

1. **New bigtiff flag**: adds the option to save result as with `tifffile.imwrite(..., bigtiff=True)`. The default behavior is not changed due to the proposed changes.

#### Testing:

The changes were tested and finished successfully. The tests can be pushed once the pending pull-request is resolved, if so desired. 

#### Impact:

This enhancement improves the robustness of the TIFF writing functionality, allowing for seamless handling of large files.

I appreciate your consideration of this pull request and look forward to any feedback you may have.
