### PR TITLE
Modularize transfer registration

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,7 +8,7 @@ frame_corrector Class
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: jnormcorre.motion_correction.frame_corrector
-   :members: __init__, register_frames, rigid_function, pwrigid_function
+   :members: __init__, register_frames, register_frames_and_transfer
 
 MotionCorrect Class
 ^^^^^^^^^^^^^^^^^^^
@@ -55,4 +55,7 @@ jnormcorre.utils.registrationarrays
    :members: __init__
 
 .. autoclass:: jnormcorre.utils.registrationarrays.RegistrationArray
+   :members: __init__
+
+.. autoclass:: jnormcorre.utils.registrationarrays.FilteredArray
    :members: __init__

--- a/jnormcorre/__init__.py
+++ b/jnormcorre/__init__.py
@@ -1,4 +1,3 @@
-# import registration array, hdf5 array, tiff array, and lazy_data_loader
 from .utils.lazy_array import lazy_data_loader
-from .utils.registrationarrays import RegistrationArray, TiffArray, Hdf5Array
+from .utils.registrationarrays import RegistrationArray, TiffArray, Hdf5Array, FilteredArray
 from jnormcorre.motion_correction import FrameCorrector, MotionCorrect

--- a/jnormcorre/__init__.py
+++ b/jnormcorre/__init__.py
@@ -1,3 +1,4 @@
 from .utils.lazy_array import lazy_data_loader
 from .utils.registrationarrays import RegistrationArray, TiffArray, Hdf5Array, FilteredArray
-from jnormcorre.motion_correction import FrameCorrector, MotionCorrect
+from jnormcorre.motion_correction import FrameCorrector, MotionCorrect, register_frames_to_template_rigid, register_frames_to_template_pwrigid, register_to_template_and_transfer_rigid, register_to_template_and_transfer_pwrigid
+from . import spatial_filters

--- a/jnormcorre/motion_correction.py
+++ b/jnormcorre/motion_correction.py
@@ -49,7 +49,7 @@ class FrameCorrector:
             min_mov (float): The minimum value of the movie, if known.
             batching (int): Specifies how many frames we register at a time. Toggle this to avoid GPU OOM errors.
         """
-        self.template = template
+        self._template = template
         self.max_shifts = max_shifts
         self.upsample_factor_fft = 10
 
@@ -145,6 +145,13 @@ class FrameCorrector:
 
         self.jitted_transfer_pwrigid_method = simplified_pwrigid_transfer_registration_func
 
+    @property
+    def template(self) -> np.ndarray:
+        return self._template
+
+    @template.setter
+    def template(self, new_template):
+        self._template = new_template
 
     def register_frames(self, frames: np.ndarray, pw_rigid: bool = False) -> np.ndarray:
         """

--- a/jnormcorre/motion_correction.py
+++ b/jnormcorre/motion_correction.py
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.ERROR)
 import numpy as np
 import tifffile
 from typing import List
-from jnormcorre.onephotonmethods import get_kernel, high_pass_filter_cv, high_pass_batch
+from jnormcorre.onephotonmethods import get_kernel, high_pass_filter_img, high_pass_batch
 from jnormcorre.utils.lazy_array import lazy_data_loader
 from tqdm import tqdm
 import math
@@ -289,7 +289,7 @@ class MotionCorrect(object):
             else:
                 self.min_mov = np.array(
                     [
-                        high_pass_filter_cv(m_, self.filter_kernel)
+                        high_pass_filter_img(m_, self.filter_kernel)
                         for m_ in self.lazy_dataset[:frame_constant, :, :]
                     ]
                 ).min()
@@ -468,7 +468,7 @@ def _motion_correct_batch_rigid(
     # Initialize template by sampling frames uniformly throughout the movie and taking the median
     if template is None:
         if filter_kernel is not None:
-            m = np.array([high_pass_filter_cv(filter_kernel, m_) for m_ in m])
+            m = np.array([high_pass_filter_img(m_, filter_kernel) for m_ in m])
 
         template = bin_median(m)
 
@@ -509,7 +509,7 @@ def _motion_correct_batch_rigid(
 
         new_templ = np.nanmedian(np.dstack([r[-1] for r in res_rig]), -1)
         if filter_kernel is not None:
-            new_templ = high_pass_filter_cv(filter_kernel, new_templ)
+            new_templ = high_pass_filter_img(new_templ, filter_kernel)
 
     total_template = new_templ
     templates = []
@@ -598,7 +598,7 @@ def _motion_correct_batch_pwrigid(
 
         new_templ = np.nanmedian(np.dstack([r[-1] for r in res_el]), -1)
         if filter_kernel is not None:
-            new_templ = high_pass_filter_cv(filter_kernel, new_templ)
+            new_templ = high_pass_filter_img(new_templ, filter_kernel)
 
     total_template = new_templ
     templates = []
@@ -753,7 +753,7 @@ def _tile_and_correct_dataloader(
                         imgs, template, max_shifts, add_to_movie
                     )
                 else:
-                    imgs_filtered = high_pass_batch(filter_kernel, imgs)
+                    imgs_filtered = high_pass_batch(imgs, filter_kernel)
                     outs = register_to_template_and_transfer_rigid(
                         imgs, imgs_filtered, template, max_shifts, add_to_movie
                     )
@@ -774,7 +774,7 @@ def _tile_and_correct_dataloader(
                         add_to_movie,
                     )
                 else:
-                    imgs_filtered = high_pass_batch(filter_kernel, imgs)
+                    imgs_filtered = high_pass_batch(imgs, filter_kernel)
                     outs = register_to_template_and_transfer_pwrigid(
                         imgs,
                         imgs_filtered,

--- a/jnormcorre/spatial_filters.py
+++ b/jnormcorre/spatial_filters.py
@@ -29,12 +29,12 @@ def compute_highpass_filter_kernel(gaussian_sigma: list[int]):
     return ker2D
 
 
-def _high_pass_filter_img(img: np.ndarray, kernel: np.ndarray):
+def _convolution_image_filter(img: np.ndarray, kernel: np.ndarray):
     """
     Filter img with kernel
     Args:
         img (np.ndarray): Shape (fov dim 1, fov dim 2). Image to be filtered
-        kernel (np.ndarray): Shape (k1, k1). Kernel for high pass filtering
+        kernel (np.ndarray): Shape (k1, k1). Kernel for filtering
     Returns:
         filtered_img (np.ndarray): Shape (fov dim 1, fov dim 2).
     """
@@ -45,5 +45,5 @@ def _high_pass_filter_img(img: np.ndarray, kernel: np.ndarray):
     filtered_frame = jax.scipy.signal.convolve(img_padded, kernel, mode="valid")
     return filtered_frame
 
-high_pass_filter_img = jit(_high_pass_filter_img)
-high_pass_batch = jit(vmap(_high_pass_filter_img, in_axes=(0, None)))
+convolution_image_filter = jit(_convolution_image_filter)
+convolution_image_filter_batch = jit(vmap(_convolution_image_filter, in_axes=(0, None)))

--- a/jnormcorre/spatial_filters.py
+++ b/jnormcorre/spatial_filters.py
@@ -29,6 +29,43 @@ def compute_highpass_filter_kernel(gaussian_sigma: list[int]):
     return ker2D
 
 
+def compute_gaussian_kernel(sigma_x: float, sigma_y: float, size: Optional[tuple]=None):
+    """
+    Constructs a Gaussian kernel for image convolution.
+
+    Args:
+        sigma_x (float): Standard deviation of the Gaussian in the x dimension.
+        sigma_y (float): Standard deviation of the Gaussian in the y dimension.
+        size (tuple of int, optional): Dimensions of the kernel (height, width).
+                                       If None, defaults to 6 * sigma_x and 6 * sigma_y.
+
+    Returns:
+        np.ndarray: 2D Gaussian kernel.
+    """
+    # Define the size of the kernel if not provided
+    if size is None:
+        size_x = int(np.ceil(6 * sigma_x))  # Covers ~99% of the Gaussian
+        size_y = int(np.ceil(6 * sigma_y))
+    else:
+        size_x, size_y = size
+
+    # Ensure the kernel size is odd
+    size_x += (size_x % 2 == 0)
+    size_y += (size_y % 2 == 0)
+
+    # Create grid for the kernel
+    x = np.linspace(-(size_x // 2), size_x // 2, size_x)
+    y = np.linspace(-(size_y // 2), size_y // 2, size_y)
+    x, y = np.meshgrid(x, y)
+
+    # Compute the Gaussian function
+    kernel = np.exp(-(x ** 2 / (2 * sigma_x ** 2) + y ** 2 / (2 * sigma_y ** 2)))
+
+    # Normalize the kernel
+    kernel /= np.sum(kernel)
+
+    return kernel
+
 def _convolution_image_filter(img: np.ndarray, kernel: np.ndarray):
     """
     Filter img with kernel

--- a/jnormcorre/spatial_filters.py
+++ b/jnormcorre/spatial_filters.py
@@ -11,16 +11,16 @@ import cv2
 from typing import *
 
 
-def get_kernel(gSig_filt: list[int]):
-    if not isinstance(gSig_filt[0], int):
+def compute_highpass_filter_kernel(gaussian_sigma: list[int]):
+    if not isinstance(gaussian_sigma[0], int):
         raise TypeError(
             "gSig_filt is a list which must contain an integer,"
-            " instead it contained{}".format(type(gSig_filt[0]))
+            " instead it contained{}".format(type(gaussian_sigma[0]))
         )
-    if gSig_filt[0] < 1:
+    if gaussian_sigma[0] < 1:
         raise ValueError("gSig_filt is a list which must contain a positive integer")
-    ksize = tuple([(3 * i) // 2 * 2 + 1 for i in gSig_filt])
-    ker = cv2.getGaussianKernel(ksize[0], gSig_filt[0])
+    ksize = tuple([(3 * i) // 2 * 2 + 1 for i in gaussian_sigma])
+    ker = cv2.getGaussianKernel(ksize[0], gaussian_sigma[0])
     ker2D = ker.dot(ker.T)
     nz = np.nonzero(ker2D >= ker2D[:, 0].max())
     zz = np.nonzero(ker2D < ker2D[:, 0].max())

--- a/jnormcorre/utils/registrationarrays.py
+++ b/jnormcorre/utils/registrationarrays.py
@@ -5,6 +5,78 @@ import numpy as np
 import h5py
 from typing import *
 
+class FilteredArray(lazy_data_loader):
+    def __init__(self,
+                 raw_data_loader: lazy_data_loader,
+                 filter_function: Callable):
+        """
+        Class for loading and filtering data; this is broadly useful because we often want to spatially filter
+        data to expose salient signals. We use this filtered version of the data to estimate shifts
+        Args:
+                raw_data_loader (lazy_data_loader): An object that supports the lazy_data_loader interface.
+                    This can be for e.g. a custom object that reads data from disk, an array in RAM (like a numpy ndarray)
+                    or anything else
+
+                filter_function (Callable): A function that applies a spatial filter to every frame of a data array. It takes
+                    an input movie of shape (frames, fov dim 1, fov dim 2) and returns a
+                    filtered movie of the same shape. The type of the output is cast to numpy array in this function.
+        """
+
+        self._raw_data_loader = raw_data_loader
+        self._filter = filter_function
+
+    @property
+    def raw_data_loader(self) -> lazy_data_loader:
+        return self._raw_data_loader
+
+    @property
+    def filter_function(self) -> Callable:
+        return self._filter
+
+    @property
+    def dtype(self) -> str:
+        """
+        data type
+        """
+        return self.raw_data_loader.dtype
+
+    @property
+    def shape(self) -> Tuple[int, int, int]:
+        """
+        Array shape (n_frames, dims_x, dims_y)
+        """
+        return self.raw_data_loader.shape
+
+    @property
+    def ndim(self) -> int:
+        """
+        Number of dimensions
+        """
+        return len(self.shape)
+
+
+    def _compute_at_indices(self, indices: Union[list, int, slice]) -> np.ndarray:
+        """
+        Lazy computation logic goes here to return frames. Slices the array over time (dimension 0) at the desired indices.
+
+        Parameters
+        ----------
+        indices: Union[list, int, slice]
+            the user's desired way of picking frames, either an int, list of ints, or slice
+             i.e. slice object or int passed from `__getitem__()`
+
+        Returns
+        -------
+        np.ndarray
+            array at the indexed slice
+        """
+        frames = self.raw_data_loader[indices]
+        if frames.ndim == 2:
+            frames = frames[None, :, :]
+        return np.array(self.filter_function(frames))
+
+
+
 
 class TiffArray(lazy_data_loader):
     def __init__(self, filename):

--- a/test/test_motion_correction.py
+++ b/test/test_motion_correction.py
@@ -89,7 +89,7 @@ class Test_mc:
 
             mc = MotionCorrect(lazy_dataset,
                                max_shifts=(6, 6), niter_rig=4, max_deviation_rigid=3,
-                               upsample_factor_grid=4, strides=(50, 50), frames_per_split=1000, gSig_filt=None,
+                               upsample_factor_grid=4, strides=(50, 50), frames_per_split=1000,
                                num_splits_to_process_els=5, num_splits_to_process_rig=5, pw_rigid=True,
                                overlaps=(10, 10), min_mov=-5, niter_els=1)
 
@@ -101,7 +101,6 @@ class Test_mc:
     @pytest.mark.parametrize("num_splits_to_process_rig", [5])
     @pytest.mark.parametrize("num_splits_to_process_els", [5])
     @pytest.mark.parametrize("frames_per_split", [100, 1000])
-    @pytest.mark.parametrize("gSig_filt", [None, (10, 10)])
     @pytest.mark.parametrize("overlaps", [(10, 10), (24, 24)])
     @pytest.mark.parametrize("pw_rigid", [True, False])
     @pytest.mark.parametrize("min_mov", [None, -5, 5])
@@ -120,7 +119,6 @@ class Test_mc:
                            pw_rigid=pw_rigid,
                            num_splits_to_process_els=num_splits_to_process_els,
                            upsample_factor_grid=upsample_factor_grid, max_deviation_rigid=max_deviation_rigid,
-                           gSig_filt=gSig_filt,
                            min_mov=min_mov, niter_els=niter_els)
 
         # Perform motion correction
@@ -144,7 +142,7 @@ class Test_mc:
                            pw_rigid=pw_rigid,
                            num_splits_to_process_els=num_splits_to_process_els,
                            upsample_factor_grid=4, max_deviation_rigid=3,
-                           gSig_filt=None, min_mov=-1, niter_els=niter_els)
+                           min_mov=-1, niter_els=niter_els)
 
         # Perform motion correction
         mc.motion_correct(save_movie=True)
@@ -162,7 +160,7 @@ class Test_mc:
                            num_splits_to_process_rig=num_splits_to_process_rig, strides=(50, 50), overlaps=(10, 10),
                            pw_rigid=pw_rigid, num_splits_to_process_els=5,
                            upsample_factor_grid=4, max_deviation_rigid=3,
-                           gSig_filt=None, min_mov=-1, niter_els=niter_els)
+                           min_mov=-1, niter_els=niter_els)
 
         # Perform motion correction
         mc.motion_correct(save_movie=True)
@@ -190,7 +188,7 @@ class Test_mc:
                            num_splits_to_process_rig=5, strides=(50, 50), overlaps=(10, 10),
                            pw_rigid=pw_rigid, num_splits_to_process_els=5,
                            upsample_factor_grid=4, max_deviation_rigid=3,
-                           gSig_filt=None, min_mov=-1, niter_els=3)
+                           min_mov=-1, niter_els=3)
 
         # Perform motion correction
         mc.motion_correct(save_movie=True)
@@ -223,7 +221,7 @@ class Test_mc:
                            num_splits_to_process_rig=5, strides=(50, 50), overlaps=(10, 10),
                            pw_rigid=pw_rigid, num_splits_to_process_els=5,
                            upsample_factor_grid=4, max_deviation_rigid=3,
-                           gSig_filt=None, min_mov=-1, niter_els=3)
+                           min_mov=-1, niter_els=3)
 
         # Perform motion correction
         mc.motion_correct(save_movie=True)
@@ -252,7 +250,7 @@ class Test_mc:
                            num_splits_to_process_rig=5, strides=(50, 50), overlaps=(10, 10),
                            pw_rigid=pw_rigid, num_splits_to_process_els=5,
                            upsample_factor_grid=4, max_deviation_rigid=3,
-                           gSig_filt=None, min_mov=-1, niter_els=3)
+                           min_mov=-1, niter_els=3)
 
         # Perform motion correction
         registration_object, target_file = mc.motion_correct(save_movie=True)
@@ -291,7 +289,7 @@ class Test_mc:
                            num_splits_to_process_rig=5, strides=(50, 50), overlaps=(10, 10),
                            pw_rigid=pw_rigid, num_splits_to_process_els=5,
                            upsample_factor_grid=4, max_deviation_rigid=3,
-                           gSig_filt=None, min_mov=-1, niter_els=3)
+                           min_mov=-1, niter_els=3)
 
         # Perform motion correction
         registration_obj, target_file = mc.motion_correct(save_movie=True)


### PR DESCRIPTION
Refactors the motion correction code to decouple the data filtering from the motion correction. Data filtering is now specified through a data array. The motion correction pipeline estimates a template on this "filtered" data. 

Afterwards, given a template, there are options to 'transfer' registration: estimate shifts using a template and reference stack and apply those shifts to another stack. 

Before, the filtering was included for only one very specific use case (1p filtering) in the main motion correction pipeline. 

Other changes: 
- frame_corrector now includes an option to transfer registration to a new stack ("register_frames_and_transfer")
- onephotomethods is renamed to spatial_filters and includes a general convolution filter function. Users now just need to specify the kernel.
- registrationarrays.RegistrationArray now includes in the constructor an option to specify a 'reference_data'. If specified, the class now estimates shifts to this stack and applies the changes to data_to_register. In effect, RegistrationArray can now be used to view registered results in the 1p case more clearly. 
- registrationarrays.FilteredArray is an array-like object for interacting with filtered versions of the data, useful for visualizing results in fastplotlib. 